### PR TITLE
Example with globalCallingHandlers() causes pkgdown::build_reference(…

### DIFF
--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -15,4 +15,7 @@ hello()
 
 \examples{
 hello()
+
+## This will cause pkgdown::build_reference() to fail
+globalCallingHandlers(NULL)
 }


### PR DESCRIPTION
…) to fail